### PR TITLE
Update index.tsx

### DIFF
--- a/packages/react-app/pages/index.tsx
+++ b/packages/react-app/pages/index.tsx
@@ -206,7 +206,7 @@ export default function Home() {
   }
 
   async function lookupAddress() {
-    let obfuscatedIdentifier = getObfuscatedIdentifier(socialIdentifier);
+    let obfuscatedIdentifier = getObfuscatedIdentifier(identifierToSend);
     let attestations = await sc!.federatedAttestationsContract.lookupAttestations(
       obfuscatedIdentifier,
       [sc!.issuerAddress]


### PR DESCRIPTION
Using `socialIdentifier` defaults the recipient to the logged-in user which whereas ought to be the `identifierToSend` as entered in the input.